### PR TITLE
Release & GoReleaser Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 .idea/
 /wifiqr
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,9 @@
 project_name: wifiqr
 builds:
-  - env: [CGO_ENABLED=0]
+  - main: ./cmd/wifiqr
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    env: [CGO_ENABLED=0]
     goos:
       - linux
       - windows
@@ -8,6 +11,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - 386
 archives:
   - replacements:
       darwin: macos

--- a/cmd/wifiqr/main.go
+++ b/cmd/wifiqr/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/reugn/wifiqr"
 )
 
-const version = "0.2.1"
+var version string = "develop"
 
 var (
 	versionParam = flag.Bool("version", false, "Show version.")


### PR DESCRIPTION
- Inject tagged version into released binary
  - No more need to modify source for each version
- Reduce size of released binaries
  - `-s`: Omit symbol and debug info
  - `-w`: Omit DWARF symbol table
- Builds for more platforms as might have been originally intended
- Git ignore files in `dist/`
  - Helps with testing GoReleaser locally with a command such as `goreleaser --skip-publish --rm-dist`