### PR TITLE
Core code refinements

### DIFF
--- a/wifiqr.go
+++ b/wifiqr.go
@@ -2,7 +2,6 @@ package wifiqr
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/skip2/go-qrcode"
 )
@@ -14,14 +13,7 @@ var defaultRecoveryLevel qrcode.RecoveryLevel = qrcode.High
 
 // InitCode returns the qrcode.QRCode based on the configuration.
 func InitCode(config *Config) (*qrcode.QRCode, error) {
-	schema := buildSchema(config)
-
-	q, err := qrcode.New(schema, defaultRecoveryLevel)
-	if err != nil {
-		return nil, err
-	}
-
-	return q, nil
+	return qrcode.New(buildSchema(config), defaultRecoveryLevel)
 }
 
 // WIFI:S:My_SSID;T:WPA;P:key goes here;H:false;
@@ -32,15 +24,13 @@ func InitCode(config *Config) (*qrcode.QRCode, error) {
 // |    +-- ESSID
 // +-- code type
 func buildSchema(config *Config) string {
-	var sb strings.Builder
-	sb.WriteString("WIFI:S:")
-	sb.WriteString(config.SSID)
-	sb.WriteString(";T:")
-	sb.WriteString(config.Encryption)
-	sb.WriteString(";P:")
-	sb.WriteString(config.Key)
-	sb.WriteString(";H:")
-	sb.WriteString(strconv.FormatBool(config.Hidden))
-	sb.WriteString(";")
-	return sb.String()
+	return "WIFI:S:" +
+		config.SSID +
+		";T:" +
+		config.Encryption +
+		";P:" +
+		config.Key +
+		";H:" +
+		strconv.FormatBool(config.Hidden) +
+		";"
 }


### PR DESCRIPTION
- Remove use of variables that aren't really needed in `InitCode`
- Eliminate the use of `strings.Builder` overhead
  - Also removes import of `strings` package
  - Speeds execution of `buildSchema` by 35%+
  - Significant decreased memory usage by `buildSchema`

The refinement of `buildSchema` is probably not really useful when
used from a command line utility, but if someone was to use this
package as part of a REST API or other utility that performs this
work repeatedly, it helps with memory use and runtime overhead.

The output of `benchcmp`:

```text
benchmark                 old ns/op     new ns/op     delta
Benchmark_buildSchema     200           125           -37.49%

benchmark                 old allocs     new allocs     delta
Benchmark_buildSchema     4              1              -75.00%

benchmark                 old bytes     new bytes     delta
Benchmark_buildSchema     120           48            -60.00%
```

Function used for benchmarking:

```go
func Benchmark_buildSchema(b *testing.B) {
	cfg := Config{
		SSID:       "testssid",
		Key:        "testkeytestkey",
		Encryption: "WPA2",
		Hidden:     false,
	}

	for i := 0; i < b.N; i++ {
		buildSchema(&cfg)
	}
}
```