### PR TITLE
UI Improvements & Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Wi-Fi QR Code generator
+# Wi-Fi QR Code Generator
+
 <img src="docs/images/qr.png" align='right'/>
 
 [![Test Status](https://github.com/reugn/wifiqr/workflows/Test/badge.svg)](https://github.com/reugn/wifiqr/actions?query=workflow%3ATest)
@@ -10,12 +11,15 @@ Create a QR code with your Wi-Fi login details.
 Use Google Lens or other application to scan it and connect automatically.
 
 ## Installation
-Pick a binary from the [releases](https://github.com/reugn/wifiqr/releases).
 
-### Build from source 
+Choose a binary from the [releases](https://github.com/reugn/wifiqr/releases).
+
+### Build from Source
+
 Download and install Go https://golang.org/doc/install.
 
 Get the package:
+
 ```sh
 go get github.com/reugn/wifiqr
 ```
@@ -23,10 +27,11 @@ go get github.com/reugn/wifiqr
 Read this [guide](https://golang.org/doc/tutorial/compile-install) on how to compile and install the application.
 
 ## Usage
+
 ```text
 Usage of ./wifiqr:
   -enc string
-        The wireless network encryption protocol (WEP, WPA, WPA2). (default "WPA2")
+        The wireless network encryption protocol (WPA2, WPA, WEP). (default "WPA2")
   -file string
         A png file to write the QR Code (prints to stdout if not set).
   -hidden
@@ -41,10 +46,12 @@ Usage of ./wifiqr:
         Show version.
 ```
 
-## Usage example
+## Usage Example
+
 ```sh
 ./wifiqr -ssid some_ssid -key 1234 -file qr.png -size 128
 ```
 
 ## License
+
 MIT

--- a/cmd/wifiqr/main.go
+++ b/cmd/wifiqr/main.go
@@ -1,90 +1,203 @@
 package main
 
 import (
-	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/manifoldco/promptui"
 	"github.com/reugn/wifiqr"
+	"github.com/skip2/go-qrcode"
+)
+
+const (
+	ssidDesc = "network name (SSID)"
+	pskDesc  = "network key (password)"
 )
 
 var version string = "develop"
 
-var (
-	versionParam = flag.Bool("version", false, "Show version.")
+// generateCode creates a WiFi QR code.
+func generateCode(ssid, key string, encoding wifiqr.EncryptionProtocol, hidden bool) (*qrcode.QRCode, error) {
+	q, err := wifiqr.InitCode(
+		wifiqr.NewConfig(ssid, key, encoding, hidden),
+	)
 
-	ssidParam   = flag.String("ssid", "", "The name of the wireless network. You'll be prompted to enter the SSID if not set.")
-	keyParam    = flag.String("key", "", "A pre-shared key (PSK). You'll be prompted to enter the key if not set.")
-	encParam    = flag.String("enc", "WPA2", "The wireless network encryption protocol (WEP, WPA, WPA2).")
-	hiddenParam = flag.Bool("hidden", false, "Hidden SSID.")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error generating WiFi QR code:", err)
+	}
 
-	fileNameParam = flag.String("file", "", "A png file to write the QR Code (prints to stdout if not set).")
-	sizeParam     = flag.Int("size", 256, "Size is both the image width and height in pixels.")
-)
+	return q, err
+}
 
-func main() {
+// saveCode saves the QR code to a file.
+func saveCode(q *qrcode.QRCode, filename string, size int) error {
+	if err := q.WriteFile(size, validateAndGetFilename(filename)); err != nil {
+		fmt.Fprintln(os.Stderr, "Error saving WiFi QR code:", err)
+		return err
+	}
+
+	fmt.Println("WiFi QR code saved to " + filename + ".")
+
+	return nil
+}
+
+// outputCode outputs the QR code to stdout or to a file.
+func outputCode(q *qrcode.QRCode, filename string, size int) error {
+	if filename == "" {
+		fmt.Println(q.ToSmallString(false))
+		return nil
+	}
+
+	return saveCode(q, filename, size)
+}
+
+// validateAndGetFilename adds the .png extension to the
+// filename if it doesn't already have one.
+func validateAndGetFilename(filename string) string {
+	const pngExt = ".png"
+
+	if filepath.Ext(filename) != pngExt {
+		filename = filename + pngExt
+	}
+
+	return filename
+}
+
+// getInput gets user input using promptui.
+func getInput(prompt string, validate func(string) error) (string, error) {
+	return (&promptui.Prompt{
+		Label:    prompt,
+		Validate: validate,
+	}).Run()
+}
+
+// inputValidator is a generic function for getting user input if the value is empty.
+func inputValidator(value, prompt string, validate func(string) error) (string, error) {
+	var err error = nil
+
+	if value == "" {
+		value, err = getInput(prompt, validate)
+	}
+
+	return value, err
+}
+
+// validateSSID	gets the SSID from the user if it is empty.
+func validateSSID(ssid string) (string, error) {
+	return inputValidator(ssid, "Enter the "+ssidDesc, func(input string) error {
+		if len(input) == 0 {
+			return errors.New("empty")
+		}
+
+		// https://serverfault.com/questions/45439/what-is-the-maximum-length-of-a-wifi-access-points-ssid
+		if len(input) > 32 {
+			return errors.New("maximum length exceeded")
+		}
+
+		return nil
+	})
+}
+
+// validateKey gets the key from the user if it is empty.
+func validateKey(key string) (string, error) {
+	return inputValidator(key, "Enter the "+pskDesc, func(input string) error {
+		if len(input) == 0 {
+			return errors.New("empty")
+		}
+
+		// no check for maximum length because it can get messy
+		return nil
+	})
+}
+
+// validateEncryption gets the encryption protocol from the user
+// if the provided protocol is empty or not valid.
+func validateEncryption(protocol string) (wifiqr.EncryptionProtocol, error) {
+	if protocol != "" {
+		encProtocol, err := wifiqr.NewEncryptionProtocol(protocol)
+		if err != nil {
+			fmt.Println("Invalid encryption protocol.")
+		} else {
+			return encProtocol, nil
+		}
+	}
+
+	prompt := promptui.Select{
+		Label: "Select the encryption type",
+		Items: []string{
+			wifiqr.WPA2.String(),
+			wifiqr.WPA.String(),
+			wifiqr.WEP.String(),
+		},
+	}
+
+	_, enc, err := prompt.Run()
+
+	encProtocol, err := wifiqr.NewEncryptionProtocol(enc)
+	if err != nil {
+		return encProtocol, err
+	}
+
+	return encProtocol, err
+}
+
+// run is tne primary function for the program.
+func run() int {
+	var (
+		versionParam = flag.Bool("version", false, "Show version.")
+
+		ssidParam = flag.String("ssid", "", "The name of the wireless network. You'll be prompted to enter the SSID if not set.")
+		keyParam  = flag.String("key", "", "A pre-shared key (PSK). You'll be prompted to enter the key if not set.")
+		encParam  = flag.String("enc", wifiqr.WPA2.String(),
+			"The wireless network encryption protocol ("+
+				strings.Join([]string{wifiqr.WPA2.String(), wifiqr.WPA.String(), wifiqr.WEP.String()}, ", ")+
+				").")
+		hiddenParam = flag.Bool("hidden", false, "Hidden SSID.")
+
+		fileNameParam = flag.String("file", "", "A png file to write the QR Code (prints to stdout if not set).")
+		sizeParam     = flag.Int("size", 256, "Size is both the image width and height in pixels.")
+
+		err error
+	)
+
 	flag.Parse()
 
 	if *versionParam {
-		fmt.Println("Version: " + version)
-		return
+		fmt.Println("Version:", version)
+		return 0
 	}
 
-	validateArguments()
-
-	config := wifiqr.NewConfig(*ssidParam, *keyParam, *encParam, *hiddenParam)
-	q, err := wifiqr.InitCode(config)
+	*ssidParam, err = validateSSID(*ssidParam)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return
+		return 1
 	}
 
-	if *fileNameParam == "" {
-		fmt.Println(q.ToSmallString(false))
-	} else {
-		fileName := validateAndGetFileName()
-		err := q.WriteFile(*sizeParam, fileName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		} else {
-			fmt.Println("QR Code was successfully saved to " + fileName + ".")
-		}
-	}
-}
-
-func validateAndGetFileName() string {
-	if filepath.Ext(*fileNameParam) != ".png" {
-		return *fileNameParam + ".png"
-	}
-	return *fileNameParam
-}
-
-func validateArguments() {
-	if *ssidParam == "" {
-		fmt.Println("Enter the name of the wireless network (SSID):")
-		*ssidParam = readLine()
-	}
-	if *keyParam == "" {
-		fmt.Println("Enter the network key (password):")
-		*keyParam = readLine()
-	}
-	if *ssidParam == "" || *keyParam == "" {
-		flag.Usage()
-		os.Exit(1)
-	}
-}
-
-func readLine() string {
-	reader := bufio.NewReader(os.Stdin)
-	line, err := reader.ReadString('\n')
+	protocol, err := validateEncryption(*encParam)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
-	// convert CRLF to LF
-	line = strings.Replace(line, "\n", "", -1)
-	return line
+
+	*keyParam, err = validateKey(*keyParam)
+	if err != nil {
+		return 1
+	}
+
+	q, err := generateCode(*ssidParam, *keyParam, protocol, *hiddenParam)
+	if err != nil {
+		return 1
+	}
+
+	if outputCode(q, *fileNameParam, *sizeParam) != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(run())
 }

--- a/cmd/wifiqr/main_test.go
+++ b/cmd/wifiqr/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"crypto/sha256"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/reugn/wifiqr"
+)
+
+func byteString(b [32]byte) string {
+	s := "[32]byte{ "
+	l := len(b) - 1
+	for i, x := range b {
+		s += strconv.Itoa(int(x))
+		if i != l {
+			s += ", "
+		}
+	}
+
+	return s + " }"
+}
+
+func Test_generateCode(t *testing.T) {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	b := make([]byte, 7100)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	longString := string(b)
+
+	type args struct {
+		ssid     string
+		key      string
+		encoding wifiqr.EncryptionProtocol
+		hidden   bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    [32]byte
+		wantErr bool
+	}{
+		{
+			name: "encoder success",
+			args: args{
+				ssid:     "testssid",
+				key:      "testkeytestkey",
+				encoding: wifiqr.WPA2,
+				hidden:   false,
+			},
+			want:    [32]byte{117, 113, 240, 31, 70, 131, 178, 237, 61, 56, 190, 135, 145, 86, 173, 81, 244, 78, 103, 173, 103, 188, 82, 70, 79, 180, 149, 217, 5, 113, 227, 25},
+			wantErr: false,
+		},
+		{
+			name: "encoder failure",
+			args: args{
+				ssid:     longString,
+				key:      "test",
+				encoding: wifiqr.WPA2,
+				hidden:   false,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateCode(tt.args.ssid, tt.args.key, tt.args.encoding, tt.args.hidden)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateCode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if data, err := got.PNG(512); err != nil {
+					t.Errorf("generateCode() error generating png: %v", err)
+				} else {
+					hash := sha256.Sum256(data)
+					if tt.want != hash {
+						t.Errorf("generateCode() png data does not match wanted hash, got: %v, want %v", byteString(hash), byteString(tt.want))
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_validateAndGetFileName(t *testing.T) {
+	type args struct {
+		filename string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no png suffix",
+			args: args{
+				filename: "imagefilename",
+			},
+			want: "imagefilename.png",
+		},
+		{
+			name: "with png suffix",
+			args: args{
+				filename: "imagefilename.png",
+			},
+			want: "imagefilename.png",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateAndGetFilename(tt.args.filename); got != tt.want {
+				t.Errorf("validateAndGetFileName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config.go
+++ b/config.go
@@ -1,5 +1,46 @@
 package wifiqr
 
+import (
+	"errors"
+	"strings"
+)
+
+type EncryptionProtocol int
+
+const (
+	WPA2 EncryptionProtocol = iota
+	WPA
+	WEP
+
+	wpa2Str = "WPA2"
+	wpaStr  = "WPA"
+	wepStr  = "WEP"
+)
+
+func (ep EncryptionProtocol) String() string {
+	switch ep {
+	case WPA2:
+		return wpa2Str
+	case WPA:
+		return wpaStr
+	case WEP:
+		return wepStr
+	}
+	return ""
+}
+
+func NewEncryptionProtocol(t string) (EncryptionProtocol, error) {
+	switch strings.ToUpper(t) {
+	case wpa2Str:
+		return WPA2, nil
+	case wpaStr:
+		return WPA, nil
+	case wepStr:
+		return WEP, nil
+	}
+	return WPA2, errors.New("no such protocol")
+}
+
 // Config is the Wi-Fi network configuration parameters.
 type Config struct {
 	// The Service Set Identifier (SSID) is the name of the wireless network.
@@ -11,13 +52,13 @@ type Config struct {
 	// A pre-shared key (PSK).
 	Key string
 	// The wireless network encryption protocol (WEP, WPA, WPA2).
-	Encryption string
+	Encryption EncryptionProtocol
 	// Defines if the SSID is ‘hidden’.
 	Hidden bool
 }
 
 // NewConfig returns a new Config.
-func NewConfig(ssid string, key string, enc string, hidden bool) *Config {
+func NewConfig(ssid string, key string, enc EncryptionProtocol, hidden bool) *Config {
 	return &Config{
 		SSID:       ssid,
 		Key:        key,

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/reugn/wifiqr
 
 go 1.15
 
-require github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+require (
+	github.com/manifoldco/promptui v0.9.0
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/wifiqr.go
+++ b/wifiqr.go
@@ -27,7 +27,7 @@ func buildSchema(config *Config) string {
 	return "WIFI:S:" +
 		config.SSID +
 		";T:" +
-		config.Encryption +
+		config.Encryption.String() +
 		";P:" +
 		config.Key +
 		";H:" +

--- a/wifiqr_test.go
+++ b/wifiqr_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCode(t *testing.T) {
-	config := wifiqr.NewConfig("ssid1", "1234", "WPA2", false)
+	config := wifiqr.NewConfig("ssid1", "1234", wifiqr.WPA2, false)
 	qrCode, err := wifiqr.InitCode(config)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
UI Improvements & Refactoring

The biggest UI improvement is the use of the
[prompui package](https://github.com/manifoldco/promptui)
for consuming user input. It's more interactive and performs
dynamic validation.

The UI now allows the user to select the encryption type from a list
if the encryption option is invalid or an empty option is specified
with `-enc=`. As before, if no encryption option is given, it defaults
to `WPA2` and the user is not prompted for the encryption type. I've tried
to make these improvements without breaking the old UI flow (yet). One
difference is invalid encryption protocols were allowed, but now they
are limited to valid types.

The `main` package has been mostly refactored. The highlights include:

- Extraction of code to smaller functions to improvement maintainability,
readability and hopefully to help accommodate future unit tests.
- Move code in `main` to a new `run` function that returns an exit code.
(Helps with future unit tests)
- Remove the use of all global variables except injected `version`.
- DRY the code.
  - SSID/password descriptions
  - `.png` extension
  - Validation code
- Improve user facing text consistency.
- Consistent use of error returns.
- Validation of SSID maximum length.
- Validation of encryption option.
- Some unit test coverage.

The core package now contains the type `EncryptionType` to help limit
the input into the API and make the strings consistent. This particular
implementation isn't ideal but works for now.

Minor edits made to the README, mostly to conform to
[markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).

Note this PR changes the API a bit, but since it's a v0.x.x series of
releases, I've assumed that's ok. The encryption protocol has changed
from a type of `string` to `EncryptionProtocol` for both `NewConfig`
and the `Config` struct.

Unit testing will require a bit of dependency injection but before going
through that, it'll be good to see how far this PR goes since I know it's
unsolicited.
