### PR TITLE
Support no encryption and escape SSID and password data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Read this [guide](https://golang.org/doc/tutorial/compile-install) on how to com
 ```text
 Usage of ./wifiqr:
   -enc string
-        The wireless network encryption protocol (WPA2, WPA, WEP). (default "WPA2")
+        The wireless network encryption protocol (WPA2, WPA, WEP, NONE). (default "WPA2")
   -file string
         A png file to write the QR Code (prints to stdout if not set).
   -hidden

--- a/config.go
+++ b/config.go
@@ -11,10 +11,17 @@ const (
 	WPA2 EncryptionProtocol = iota
 	WPA
 	WEP
+	NONE
 
 	wpa2Str = "WPA2"
 	wpaStr  = "WPA"
 	wepStr  = "WEP"
+	noneStr = "NONE"
+
+	wpa2Code = wpa2Str
+	wpaCode  = wpaStr
+	wepCode  = wepStr
+	noneCode = "nopass"
 )
 
 func (ep EncryptionProtocol) String() string {
@@ -25,6 +32,22 @@ func (ep EncryptionProtocol) String() string {
 		return wpaStr
 	case WEP:
 		return wepStr
+	case NONE:
+		return noneStr
+	}
+	return ""
+}
+
+func (ep EncryptionProtocol) Code() string {
+	switch ep {
+	case WPA2:
+		return wpa2Code
+	case WPA:
+		return wpaCode
+	case WEP:
+		return wepCode
+	case NONE:
+		return noneCode
 	}
 	return ""
 }
@@ -37,6 +60,8 @@ func NewEncryptionProtocol(t string) (EncryptionProtocol, error) {
 		return WPA, nil
 	case wepStr:
 		return WEP, nil
+	case noneStr, noneCode, "":
+		return NONE, nil
 	}
 	return WPA2, errors.New("no such protocol")
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,151 @@
+package wifiqr
+
+import (
+	"testing"
+)
+
+func TestNewEncryptionProtocol(t *testing.T) {
+	type args struct {
+		t string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    EncryptionProtocol
+		wantErr bool
+	}{
+		{
+			name: "WPA",
+			args: args{
+				t: "WPA",
+			},
+			want:    WPA,
+			wantErr: false,
+		},
+		{
+			name: "WPA2",
+			args: args{
+				t: "WPA2",
+			},
+			want:    WPA2,
+			wantErr: false,
+		},
+		{
+			name: "WEP",
+			args: args{
+				t: "WEP",
+			},
+			want:    WEP,
+			wantErr: false,
+		},
+		{
+			name: "NONE",
+			args: args{
+				t: "NONE",
+			},
+			want:    NONE,
+			wantErr: false,
+		},
+		{
+			name: "error",
+			args: args{
+				t: "invalid",
+			},
+			want:    WPA2,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewEncryptionProtocol(tt.args.t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEncryptionProtocol() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NewEncryptionProtocol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncryptionProtocol_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ep   EncryptionProtocol
+		want string
+	}{
+		{
+			name: "WPA",
+			ep:   WPA,
+			want: "WPA",
+		},
+		{
+			name: "WPA2",
+			ep:   WPA2,
+			want: "WPA2",
+		},
+		{
+			name: "WEP",
+			ep:   WEP,
+			want: "WEP",
+		},
+		{
+			name: "NONE",
+			ep:   NONE,
+			want: "NONE",
+		},
+		{
+			name: "NONE",
+			ep:   99,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ep.String(); got != tt.want {
+				t.Errorf("EncryptionProtocol.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncryptionProtocol_Code(t *testing.T) {
+	tests := []struct {
+		name string
+		ep   EncryptionProtocol
+		want string
+	}{
+		{
+			name: "WPA",
+			ep:   WPA,
+			want: "WPA",
+		},
+		{
+			name: "WPA2",
+			ep:   WPA2,
+			want: "WPA2",
+		},
+		{
+			name: "WEP",
+			ep:   WEP,
+			want: "WEP",
+		},
+		{
+			name: "NONE",
+			ep:   NONE,
+			want: "nopass",
+		},
+		{
+			name: "NONE",
+			ep:   99,
+			want: "",
+		}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ep.Code(); got != tt.want {
+				t.Errorf("EncryptionProtocol.Code() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/wifiqr.go
+++ b/wifiqr.go
@@ -16,6 +16,22 @@ func InitCode(config *Config) (*qrcode.QRCode, error) {
 	return qrcode.New(buildSchema(config), defaultRecoveryLevel)
 }
 
+// escapeString escapes the special characters with a backslash.
+func escapeString(in string) string {
+	// https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11
+	out := ""
+	for _, c := range in {
+		switch c {
+		case '\\', ';', ',', '"', ':':
+			out += `\` + string(c)
+		default:
+			out += string(c)
+		}
+	}
+
+	return out
+}
+
 // WIFI:S:My_SSID;T:WPA;P:key goes here;H:false;
 // ^    ^         ^     ^               ^
 // |    |         |     |               +-- hidden SSID (true/false)
@@ -25,11 +41,11 @@ func InitCode(config *Config) (*qrcode.QRCode, error) {
 // +-- code type
 func buildSchema(config *Config) string {
 	return "WIFI:S:" +
-		config.SSID +
+		escapeString(config.SSID) +
 		";T:" +
-		config.Encryption.String() +
+		config.Encryption.Code() +
 		";P:" +
-		config.Key +
+		escapeString(config.Key) +
 		";H:" +
 		strconv.FormatBool(config.Hidden) +
 		";"

--- a/wifiqr.go
+++ b/wifiqr.go
@@ -2,6 +2,7 @@ package wifiqr
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/skip2/go-qrcode"
 )
@@ -17,19 +18,14 @@ func InitCode(config *Config) (*qrcode.QRCode, error) {
 }
 
 // escapeString escapes the special characters with a backslash.
-func escapeString(in string) string {
+func escapeString(s string) string {
 	// https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11
-	out := ""
-	for _, c := range in {
-		switch c {
-		case '\\', ';', ',', '"', ':':
-			out += `\` + string(c)
-		default:
-			out += string(c)
-		}
+
+	for _, c := range []byte{'\\', ';', ',', '"', ':'} {
+		s = strings.Replace(s, string(c), `\`+string(c), -1)
 	}
 
-	return out
+	return s
 }
 
 // WIFI:S:My_SSID;T:WPA;P:key goes here;H:false;

--- a/wifiqr_test.go
+++ b/wifiqr_test.go
@@ -1,16 +1,14 @@
-package wifiqr_test
+package wifiqr
 
 import (
 	"hash/fnv"
 	"reflect"
 	"testing"
-
-	"github.com/reugn/wifiqr"
 )
 
 func TestCode(t *testing.T) {
-	config := wifiqr.NewConfig("ssid1", "1234", wifiqr.WPA2, false)
-	qrCode, err := wifiqr.InitCode(config)
+	config := NewConfig("ssid1", "1234", WPA2, false)
+	qrCode, err := InitCode(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,5 +24,117 @@ func hashCode(s string) int {
 func assertEqual(t *testing.T, a interface{}, b interface{}) {
 	if !reflect.DeepEqual(a, b) {
 		t.Fatalf("%v != %v", a, b)
+	}
+}
+
+func Test_escapeString(t *testing.T) {
+	type args struct {
+		in string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "all escapes",
+			args: args{
+				in: `abc\;,":xyz`,
+			},
+			want: `abc\\\;\,\"\:xyz`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeString(tt.args.in); got != tt.want {
+				t.Errorf("escapeString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildSchema(t *testing.T) {
+	type args struct {
+		config *Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no encryption protocol",
+			args: args{
+				config: &Config{
+					SSID:       "ssid1",
+					Encryption: NONE,
+				},
+			},
+			want: `WIFI:S:ssid1;T:nopass;P:;H:false;`,
+		},
+		{
+			name: "WEP encryption protocol",
+			args: args{
+				config: &Config{
+					SSID:       "ssid1",
+					Key:        "key1",
+					Encryption: WEP,
+				},
+			},
+			want: `WIFI:S:ssid1;T:WEP;P:key1;H:false;`,
+		},
+		{
+			name: "WPA encryption protocol",
+			args: args{
+				config: &Config{
+					SSID:       "ssid1",
+					Key:        "key1",
+					Encryption: WPA,
+				},
+			},
+			want: `WIFI:S:ssid1;T:WPA;P:key1;H:false;`,
+		},
+		{
+			name: "WPA2 encryption protocol",
+			args: args{
+				config: &Config{
+					SSID:       "ssid1",
+					Key:        "key1",
+					Encryption: WPA2,
+				},
+			},
+			want: `WIFI:S:ssid1;T:WPA2;P:key1;H:false;`,
+		},
+		{
+			name: "WPA2 encryption protocol, hidden",
+			args: args{
+				config: &Config{
+					SSID:       "ssid1",
+					Key:        "key1",
+					Encryption: WPA2,
+					Hidden:     true,
+				},
+			},
+			want: `WIFI:S:ssid1;T:WPA2;P:key1;H:true;`,
+		},
+		{
+			name: "escaped characters, WPA2 encryption protocol",
+			args: args{
+				config: &Config{
+					SSID:       `abc\;,":xyz`,
+					Key:        `xyz\;,":abc`,
+					Encryption: WPA2,
+					Hidden:     false,
+				},
+			},
+			want: `WIFI:S:abc\\\;\,\"\:xyz;T:WPA2;P:xyz\\\;\,\"\:abc;H:false;`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildSchema(tt.args.config); got != tt.want {
+				t.Errorf("buildSchema() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Background information for these changes can be found on [ZXing's Wi-Fi Network config](https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11) documentation section which is also referenced from the [Wikipedia page and section on wifi networks](https://en.wikipedia.org/wiki/QR_code#Joining_a_Wi%E2%80%91Fi_network).

## No Encryption

No WiFi encryption is now supported. This is enabled on the command line with the `-enc` option which can be set to `NONE`, `NOPASS`, or empty with `-enc ""` and the user will not be prompted for a password. In the case where an invalid protocol is specified, the selection list now includes a `NONE` option after which the user is not prompted for a password. As before, the encryption protocol defaults to WPA2.

## Escape of SSID and Password

Special characters in the SSID and password are now escaped with backslashes (`\`).

## Increased Unit Testing

Unit tests have been added to support some of the new functionality, for building the string used to generate the QR code (`buildSchema`) and a few other functions.
